### PR TITLE
enable renovatebot for the fork

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
         "fileMatch": [
             "^{{cookiecutter.project_name}}\/((workflow-templates|\\.github\/workflows)\/[^/]+\\.ya?ml$|action\\.ya?ml$)"
         ]
-    }
+    },
+    "includeForks": true
 }


### PR DESCRIPTION
It seems that renovate bot does not work by default on the forked repositories.