### PR TITLE
add configuration for automatically generated release notes

### DIFF
--- a/{{cookiecutter.project_name}}/.github/release.yml
+++ b/{{cookiecutter.project_name}}/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog


### PR DESCRIPTION
Avoid adding PRs with `skip-changelog` label to automatically drafted release notes