### PR TITLE
gha: fix concurrency

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ env:
   FORCE_COLOR: "1"
 
 concurrency:
-  group: ${{"{{"}} github.workflow {{"}}"}}-${{"{{"}} github.event.pull_request.number || github.sha {{"}}"}}
+  group: ${{"{{"}} github.workflow {{"}}"}}-${{"{{"}} github.head_ref || github.run_id {{"}}"}}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Before, if we had a test running in CI for the default branch, and immediately proceed to make a release, the test for that release would start and cancel the running test from the default branch. This would show as if the tests failed on the default branch with a red cross on the repository. 

Now we use `github.head_ref` which is only available for `pull_request` and that's what we intended: to run only one instance of tests in the pull request and cancel old ones running. We don't have this on other events, i.e. release or push to main events, so we fallback to `github.run_id` which is unique to the workflow run, so it won't cancel those runs. :)