### PR TITLE
tests: run only on either PR or on push to main

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -2,8 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
When we create a PR, the CI runs multiple jobs for both `pull_request` event and `push` event, spawning >20 jobs.
I think it's okay for us to only run on push to `main` branch, and in PR. If other branch needs CI to run, we can open a draft PR temporarily which is a good thing imo.