### PR TITLE
release builds: only try to upload package on release

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   release:
     types: [published]
-
   workflow_dispatch:
 
 env:
@@ -33,6 +32,7 @@ jobs:
       run: nox -s build
 
     - name: Upload package
+      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{"{{"}} secrets.PYPI_TOKEN {{"}}"}}


### PR DESCRIPTION
As we do in https://github.com/iterative/dvc/blob/7b3b4b373b5e383f30792cd25d9d08be62db8275/.github/workflows/packages.yaml#L94.