### PR TITLE
add gitattributes for end-of-line normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/{{cookiecutter.project_name}}/.gitattributes
+++ b/{{cookiecutter.project_name}}/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
See https://github.com/cjolowicz/cookiecutter-hypermodern-python/pull/164, and https://github.com/actions/checkout/issues/135. `pre-commit` fails because the files get checked out with `CRLF` in windows by default.