### PR TITLE
add action to update template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict
+        args: ['--assume-in-merge']
       - id: check-toml
       - id: check-yaml
       - id: debug-statements

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,66 @@
+name: Update iterative/py-template
+description: "Update py-template generated template"
+branding:
+  icon: package
+  color: purple
+
+runs:
+  using: composite
+  steps:
+  - name: Set up Python
+    uses: actions/setup-python@v4
+    with:
+      python-version: '3.10'
+
+  - name: Install cruft
+    shell: bash
+    run: pip install cruft==2.11.1  # renovate: datasource=pypi
+
+  - name: Update template via cruft
+    shell: bash
+    id: cruft
+    run: |
+      echo "::set-output name=template::$(cat .cruft.json | jq '.template' -r)"
+      echo "::set-output name=old_commit::$(cat .cruft.json | jq '.commit' -r)"
+      cruft update -y
+      echo "::set-output name=new_commit::$(cat .cruft.json | jq '.commit' -r)"
+
+  - name: Check current state
+    shell: bash
+    run: |
+      git status --untracked-files=all
+      git diff
+
+  - name: Try to apply reject hunks
+    shell: bash
+    id: apply-rejects
+    run: |
+      for reject in $(git ls-files --others --exclude-standard '*.rej'); do
+        file=${reject%.rej}
+        cat ${reject}
+        patch -p1 --merge --no-backup-if-mismatch ${file} < ${reject} || echo "  - \`${file}\`" >> /tmp/conflicts
+        rm ${reject}
+        echo
+      echo "::set-output name=conflicts::$(cat /tmp/conflicts)"
+      done
+
+  - name: Check diff
+    id: diff
+    shell: bash
+    run: |
+      git status --untracked-files=all
+      echo "::set-output name=changes::$(git diff)"
+
+  - name: Create PR
+    if: ${{ steps.diff.outputs.changes != '' }}
+    uses: peter-evans/create-pull-request@v4
+    with:
+      commit-message: update template
+      title: update template
+      body: |
+        Automated changes to update template with ${{ steps.cruft.outputs.template }}.
+
+        ${{ steps.apply-rejects.outputs.conflicts != '' && 'There may be merge conflicts in these files that may need to be resolved manually:' || '' }}
+        ${{ steps.apply-rejects.outputs.conflicts }}
+
+        __See Changelog__: ${{ steps.cruft.outputs.template }}/compare/${{ steps.cruft.outputs.old_commit }}...${{ steps.cruft.outputs.new_commit }}.

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,13 @@
                 "\\s*- (?<depName>.*?)==(?<currentValue>.*?)\\s+"
             ],
             "datasourceTemplate": "pypi"
+        },
+        {
+            "fileMatch": ["action.yml"],
+            "matchStrings": [
+                ".*?(?<depName>\\S+(?===))==(?<currentValue>.*?)\\s+#\\s+renovate: datasource=pypi\\s"
+            ],
+            "datasourceTemplate": "pypi"
         }
     ]
 }

--- a/{{cookiecutter.project_name}}/.github/workflows/update-template.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/update-template.yaml
@@ -13,20 +13,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: Update template via cruft
-      id: update
-      run: |
-        pip install cruft
-        cruft update -y
-        echo "::set-output name=changes::$(git diff)"
-
-    - name: Create PR
-      if: {% raw %}${{ steps.update.outputs.changes != '' }}{% endraw %}
-      uses: peter-evans/create-pull-request@v4
-      with:
-        commit-message: update template
-        title: update template
+      uses: iterative/py-template@main

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict
+        args: ['--assume-in-merge']
       - id: check-toml
       - id: check-yaml
       - id: debug-statements


### PR DESCRIPTION
To test this, I have a PR open in https://github.com/iterative/scmrepo/pull/134, that uses this action.
You can test this action over scmrepo with following command:
```console
gh workflow run update-template.yaml -R iterative/scmrepo -r update=template
```

You can also add the following content to a workflow file, eg: `.github/workflows/update-template.yml`, that will trigger this action and create a PR for you.
```yaml
name: Update template

on:
  schedule:
    - cron: '5 1 * * *'  # every day at 01:05
  workflow_dispatch:

jobs:
  update:
    runs-on: ubuntu-latest
    steps:
    - name: Check out the repository
      uses: actions/checkout@v3

    - name: Update template via cruft
      uses: iterative/py-template@add-update-action
```