### PR TITLE
readd flake8-bandit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - flake8-bandit==4.1.1
           - flake8-broken-line==0.5.0
           - flake8-bugbear==22.8.23
           - flake8-comprehensions==3.10.0

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - flake8-bandit==4.1.1
           - flake8-broken-line==0.5.0
           - flake8-bugbear==22.8.23
           - flake8-comprehensions==3.10.0


### PR DESCRIPTION
It was incompatible with flake8 v5, so I had removed it temporarily. Since it's fixed now, I am readding it back.