### PR TITLE
Use github repo for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
       - id: flake8


### PR DESCRIPTION
Docs indicate to use GitHub repo https://flake8.pycqa.org/en/latest/user/using-hooks.html