### PR TITLE
noxfile: Add mypy args `--install-types`  and `--non-interactive`

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -36,7 +36,7 @@ def lint(session: nox.Session) -> None:
 
     args = *(session.posargs or ("--show-diff-on-failure",)), "--all-files"
     session.run("pre-commit", "run", *args)
-    session.run("python", "-m", "mypy")
+    session.run("python", "-m", "mypy", "--install-types", "--non-interactive")
     session.run("python", "-m", "pylint", *locations)
 
 


### PR DESCRIPTION
Avoids downstream projects to install `{X}-types` for mypy