### PR TITLE
dependabot: explicitely define pytest plugins instead of using pytest-*

### DIFF
--- a/{{cookiecutter.project_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_name}}/.github/dependabot.yml
@@ -10,7 +10,10 @@ updates:
     # Update via cruft
     ignore:
       - dependency-name: "mkdocs*"
-      - dependency-name: "pytest*"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-mock"
+      - dependency-name: "pytest-sugar"
       - dependency-name: "pylint"
       - dependency-name: "mypy"
 


### PR DESCRIPTION
fixes #96
