### PR TITLE
change max line length to 88 for formatters, linters

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -64,7 +64,7 @@ warn_unreachable = true
 files = ["src", "tests"]
 
 [tool.pylint.format]
-max-line-length=88
+max-line-length = 88
 
 [tool.pylint.message_control]
 enable = ["c-extension-no-member", "no-else-return"]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 
 [tool.black]
-line-length = 79
+line-length = 88
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -25,7 +25,7 @@ exclude = '''
 [tool.isort]
 profile = "black"
 known_first_party = ["{{ cookiecutter.package_name }}"]
-line_length = 79
+line_length = 88
 
 [tool.pytest.ini_options]
 addopts = "-ra"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -63,6 +63,9 @@ warn_redundant_casts = true
 warn_unreachable = true
 files = ["src", "tests"]
 
+[tool.pylint.format]
+max-line-length=88
+
 [tool.pylint.message_control]
 enable = ["c-extension-no-member", "no-else-return"]
 

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -60,7 +60,7 @@ ignore=
     W503, # Line break occurred before a binary operator
     P1,  # unindexed parameters in the str.format, see:
     # https://pypi.org/project/flake8-string-format/
-max_line_length = 79
+max_line_length = 88
 max-complexity = 15
 select = B,C,E,F,W,T4,B902,T,P
 show_source = true


### PR DESCRIPTION
We've discussed increasing the max line length from 79 to 88 (the default for the black formatter) as many people find 79 causes code to become too spread out vertically, especially when using black.