### PR TITLE
deps: update mkdocs

### DIFF
--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -28,11 +28,11 @@ install_requires=
 [options.extras_require]
 {%- if cookiecutter.docs != "False" %}
 docs =
-    mkdocs==1.3.1
-    mkdocs-gen-files==0.3.5
-    mkdocs-material==8.4.1
-    mkdocs-section-index==0.3.4
-    mkdocstrings-python==0.7.1
+    mkdocs==1.5.2
+    mkdocs-gen-files==0.5.0
+    mkdocs-material==9.3.1
+    mkdocs-section-index==0.3.6
+    mkdocstrings-python==1.6.3
 {%- endif %}
 tests =
     pytest==7.2.0


### PR DESCRIPTION
fixes `safety` CVE warning for mkdocs-material < 9.3.1 (see https://github.com/iterative/dvc-task/actions/runs/6008962860/job/16297498866)