### PR TITLE
pre-commit-config: add missing toml dependency for bandit

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -51,4 +51,4 @@ repos:
     hooks:
       - id: bandit
         args: [-c, pyproject.toml]
-        additional_dependencies: ["toml"]
+        additional_dependencies: ["bandit[toml]"]


### PR DESCRIPTION
The missing `toml` dependency for bandit would result in it failing due to the missing toml module