### PR TITLE
lint: use ruff instead of isort/black/flake8/pylint

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,10 +1,6 @@
 default_language_version:
   python: python3
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -23,6 +19,12 @@ repos:
         args: ['--fix=lf']
       - id: sort-simple-yaml
       - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.5'
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.5
     hooks:
@@ -33,22 +35,3 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear==23.7.10
-          - flake8-comprehensions==3.14.0
-          - flake8-debugger==4.1.2
-          - flake8-string-format==0.3.0
-  - repo: https://github.com/pycqa/bandit
-    rev: 1.7.5
-    hooks:
-      - id: bandit
-        args: [-c, pyproject.toml]
-        additional_dependencies: ["bandit[toml]"]

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -37,7 +37,6 @@ def lint(session: nox.Session) -> None:
     args = *(session.posargs or ("--show-diff-on-failure",)), "--all-files"
     session.run("pre-commit", "run", *args)
     session.run("python", "-m", "mypy")
-    session.run("python", "-m", "pylint", *locations)
 
 
 @nox.session

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -39,7 +39,6 @@ tests =
     pytest-sugar==0.9.5
     pytest-cov==3.0.0
     pytest-mock==3.8.2
-    pylint==2.15.0
     mypy==0.971
 dev =
     %(tests)s
@@ -52,20 +51,3 @@ exclude =
     tests
     tests.*
 where=src
-
-[flake8]
-ignore=
-    # Whitespace before ':'
-    E203
-    # Too many leading '#' for block comment
-    E266
-    # Line break occurred before a binary operator
-    W503
-    # unindexed parameters in the str.format, see:
-    # https://pypi.org/project/flake8-string-format/
-    P1
-max_line_length = 88
-max-complexity = 15
-select = B,C,E,F,W,T4,B902,T,P
-show_source = true
-count = true


### PR DESCRIPTION
Just tired of it in other projects and want to make it consistent with dvc in one place.

Fixes #111
Also makes #86 easier by removing flake8 config.