### PR TITLE
set default for conflicting rules

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -101,6 +101,8 @@ ignore = [
     "ISC001", # single-line-implicit-string-concatenation
     "SIM105", # suppressible-exception
     "SIM108", # if-else-block-instead-of-if-exp
+    "D203", # one blank line before class
+    "D213", # multi-line-summary-second-line
 ]
 select = ["ALL"]
 show-source = true


### PR DESCRIPTION
When enabling all rules, some rules are conflicting, resulting in the following errors:

```console
warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.```
