### PR TITLE
drop safety

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,4 +65,4 @@ jobs:
         run: |
           cd ${{ matrix.context.project_name }}
           nox
-          nox -s lint safety build dev ${{ matrix.context.docs && 'docs'}}
+          nox -s lint build dev ${{ matrix.context.docs && 'docs'}}

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,6 @@ Features
 - Coverage reporting with Codecov_
 - Static type-checking with mypy_
 - Automated Python syntax upgrades with pyupgrade_
-- Security audit with Safety_
 - setuptools as backend, build as frontend
 
 The template supports Python 3.8, 3.9, 3.10 and 3.11.
@@ -47,7 +46,6 @@ The template supports Python 3.8, 3.9, 3.10 and 3.11.
 .. _Nox: https://nox.thea.codes/
 .. _PyPI: https://pypi.org/
 .. _Read the Docs: https://readthedocs.org/
-.. _Safety: https://github.com/pyupio/safety
 .. _mypy: http://mypy-lang.org/
 .. _pre-commit: https://pre-commit.com/
 .. _pytest: https://docs.pytest.org/en/latest/

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
           pip --version
           nox --version
 
-      - name: Lint code and check dependencies
-        run: nox -s lint safety
+      - name: Lint code
+        run: nox -s lint
 
       - name: Run tests
         run: nox -s tests-{% raw %}${{ matrix.nox_pyv || matrix.pyv }}{% endraw %} -- --cov-report=xml

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -43,14 +43,6 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session
-def safety(session: nox.Session) -> None:
-    """Scan dependencies for insecure packages."""
-    session.install(".[dev]")
-    session.install("safety")
-    session.run("safety", "check", "--full-report")
-
-
-@nox.session
 def build(session: nox.Session) -> None:
     session.install("build", "setuptools", "twine")
     session.run("python", "-m", "build")


### PR DESCRIPTION
GitHub has dependency alerts and dependency security updates that can replace `safety`.

For the past few months, safety has been raising vulnerability errors for `pip` and now `jinja2`. The latter is a dependency of `safety` itself, and both CVEs are disputed.

Which is breaking CI for us.

Closes #132.